### PR TITLE
Fix bug

### DIFF
--- a/lib/acts_as_approvable/acts_as_approvable.rb
+++ b/lib/acts_as_approvable/acts_as_approvable.rb
@@ -137,7 +137,7 @@ module ActsAsApprovable
           original, changed_to = changes[attr]
 
           @approval.object[attr] = changed_to
-          write_attribute(attr.to_sym, original)
+          write_attribute(attr.to_s, original)
         end
       end
     end

--- a/lib/acts_as_approvable/approval.rb
+++ b/lib/acts_as_approvable/approval.rb
@@ -55,9 +55,10 @@ class Approval < ActiveRecord::Base
     raise "This is a stale approval" if stale? and !options.delete(:force)
 
     if update?
-      data = Hash[object.map do |attr, value|
-        [attr, value] if item.attributes.include?(attr)
-      end.flatten]
+      data = {}
+      object.each do |attr, value|
+        data[attr] = value if item.attributes.include?(attr)
+      end
 
       item.without_approval { update_attributes!(data) }
     elsif create? && item.approval_state.present?

--- a/lib/acts_as_approvable/approval.rb
+++ b/lib/acts_as_approvable/approval.rb
@@ -57,7 +57,7 @@ class Approval < ActiveRecord::Base
     if update?
       data = {}
       object.each do |attr, value|
-        data[attr] = value if item.attributes.include?(attr)
+        data[attr] = value if item.attribute_names.include?(attr)
       end
 
       item.without_approval { update_attributes!(data) }

--- a/test/acts_as_approvable_model_test.rb
+++ b/test/acts_as_approvable_model_test.rb
@@ -89,7 +89,7 @@ class ActsAsApprovableModelTest < Test::Unit::TestCase
       end
 
       should 'update the target item' do
-        assert_equal @approval.object[:description], @approval.item.description
+        assert_equal @approval.object['description'], @approval.item.description
       end
 
       should 'raise an error if approved again' do

--- a/test/acts_as_approvable_model_test.rb
+++ b/test/acts_as_approvable_model_test.rb
@@ -74,6 +74,12 @@ class ActsAsApprovableModelTest < Test::Unit::TestCase
       assert !@approval.rejected?
     end
 
+    should 'check attributes in object' do
+      @approval.object['foo'] = 'bar'
+      @approval.approve!
+      assert_equal @approval.object['description'], @approval.item.description
+    end
+
     context 'that is accepted' do
       setup { @approval.approve! }
 


### PR DESCRIPTION
for lines 58-61 of `approval.rb` is wrong, because:

``` ruby
Hash['a', 1, 'b', 2] # => { 'a' => 1, 'b' => 2 }
Hash[['a', 1, 'b', 2]] # => {}
```

Another way would be:

``` ruby
data = Hash[*object.to_a.select do |attr_value|
  item.attributes.include?(attr_value.first)
end.flatten]
```

but that seemed too fancy, and also slower:

``` ruby
n = 50_000
object = { 'a' => 1, 'c' => 3 }
attributes = { 'a' => 2, 'b' => 4 }

Benchmark.bm(6) do |b|
  b.report 'fancy' do
    n.times do
      data = Hash[*object.to_a.select do |attr_value|
        attributes.include?(attr_value.first)
      end.flatten]
    end
  end

  b.report 'boring' do
    n.times do
      data = {}
      object.each do |attr, value|
        data[attr] = value if attributes.include?(attr)
      end
    end
  end
end
```

returns

```
            user     system      total        real
fancy   0.620000   0.000000   0.620000 (  0.623037)
boring  0.190000   0.000000   0.190000 (  0.187836)
```
