### PR TITLE
Adds attr_accessible for Rails > 3.2.3 compatibility

### DIFF
--- a/lib/acts_as_approvable/approval.rb
+++ b/lib/acts_as_approvable/approval.rb
@@ -3,6 +3,8 @@ class Approval < ActiveRecord::Base
   # Enumeration of available states.
   STATES = %w(pending approved rejected)
 
+  attr_accessible :event, :state, :object, :original, :reason
+
   belongs_to :item,  :polymorphic => true
 
   validates_presence_of  :item


### PR DESCRIPTION
I added attr_accessible for :event, :state, :object, :original  in approval.rb as I ran into the mass assignment issue using the gem on a new project.

Thought it might be useful for others too.
